### PR TITLE
Reboot instances before running perfromance seq

### DIFF
--- a/playbooks/packet_gen/trex/performance_scenario.yml
+++ b/playbooks/packet_gen/trex/performance_scenario.yml
@@ -16,6 +16,14 @@
         name: roles/post_install/dynamic_host_inventory
       loop: "{{ dynamic_instances }}"
 
+    - name: Reboot instances to make sure nics are bound to kernel
+      openstack.cloud.server_action:
+        cloud: "{{ cloud_name | default('overcloud') }}"
+        action: reboot_soft
+        server: "{{ item.name }}"
+        timeout: 300
+      loop: "{{ dynamic_instances }}"
+
 - hosts: "{{ dut_compute | default(omit) }}"
   become: true
   roles:


### PR DESCRIPTION
Reboot VMs to allow cunsecutive runs using the same trex instance